### PR TITLE
Added an AppContent component in App.jsx to manage history-based moda…

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from 'react-router-dom'; // Import useLocation
+import { BrowserRouter as Router, Routes, Route, Navigate, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { lazy, Suspense, useState, useEffect } from 'react';
 import './App.css';
 
@@ -15,6 +15,7 @@ import Modal from './components/Modal';
 import Leaderboard from './components/Leaderboard';
 import TutorialGuide from './components/TutorialGuide';
 import DeviceGuard from './components/DeviceGuard';
+import ProfileModal from './components/ProfileModal';
 
 // Lazy-loaded pages for code splitting
 const Landing = lazy(() => import('./pages/Landing'));
@@ -132,6 +133,31 @@ function AppRoutes() {
   );
 }
 
+function AppContent() {
+  const location = useLocation();
+  const state = location.state || {};
+  const backgroundLocation = state.backgroundLocation;
+
+  const ProfileModalRoute = () => {
+    const navigate = useNavigate();
+    const { netid } = useParams();
+    const handleClose = () => navigate(-1);
+    return <ProfileModal isOpen={true} onClose={handleClose} netid={netid} />;
+  };
+
+  return (
+    <>
+      <AppRoutes location={backgroundLocation || location} />
+      {backgroundLocation && (
+        <Routes>
+          <Route path="/profile/:netid" element={<ProfileModalRoute />} />
+        </Routes>
+      )}
+      <TutorialGuide />
+    </>
+  );
+}
+
 function App() {
   return (
     <Router>
@@ -140,9 +166,7 @@ function App() {
           <SocketProvider>
             <RaceProvider>
               <DeviceGuard>
-                <AppRoutes />
-                {/* Render the tutorial guide */}
-                <TutorialGuide />
+                <AppContent />
               </DeviceGuard>
             </RaceProvider>
           </SocketProvider>

--- a/client/src/components/Leaderboard.jsx
+++ b/client/src/components/Leaderboard.jsx
@@ -4,7 +4,7 @@ import { useAuth } from '../context/AuthContext';
 import PropTypes from 'prop-types';
 import './Leaderboard.css';
 import defaultProfileImage from '../assets/icons/default-profile.svg';
-import ProfileModal from './ProfileModal.jsx';
+import { useNavigate, useLocation } from 'react-router-dom';
 
 const DURATIONS = [15, 30, 60, 120];
 const PERIODS = ['daily', 'alltime'];
@@ -38,9 +38,8 @@ function Leaderboard({ defaultDuration = 15, defaultPeriod = 'alltime', layoutMo
   const [leaderboard, setLeaderboard] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-  // State to track which user's profile to view
-  const [selectedProfileNetid, setSelectedProfileNetid] = useState(null);
-  const [showProfileModal, setShowProfileModal] = useState(false);
+  const navigate = useNavigate();
+  const location = useLocation();
 
   useEffect(() => {
     // Fetch from API directly if socket isn't available (user not logged in)
@@ -98,10 +97,8 @@ function Leaderboard({ defaultDuration = 15, defaultPeriod = 'alltime', layoutMo
   }, [socket, duration, period]);
 
   const handleAvatarClick = (_avatarUrl, netid) => {
-    // Only proceed if user is authenticated via CAS
     if (!authenticated) return;
-    setSelectedProfileNetid(netid);
-    setShowProfileModal(true);
+    navigate(`/profile/${netid}`, { state: { backgroundLocation: location } });
   };
 
   return (
@@ -228,14 +225,6 @@ function Leaderboard({ defaultDuration = 15, defaultPeriod = 'alltime', layoutMo
         </>
       )}
 
-      {/* Profile Modal for viewing user profiles (only for authenticated users) */}
-      {authenticated && showProfileModal && (
-        <ProfileModal
-          isOpen={showProfileModal}
-          onClose={() => setShowProfileModal(false)}
-          netid={selectedProfileNetid}
-        />
-      )}
     </>
   );
 }

--- a/client/src/components/PlayerStatusBar.jsx
+++ b/client/src/components/PlayerStatusBar.jsx
@@ -3,13 +3,13 @@ import './PlayerStatusBar.css';
 import defaultProfileImage from '../assets/icons/default-profile.svg';
 import { useAuth } from '../context/AuthContext';
 import axios from 'axios';
-import ProfileModal from './ProfileModal.jsx';
+import { useNavigate, useLocation } from 'react-router-dom';
 
 function PlayerStatusBar({ players, isRaceInProgress, currentUser, onReadyClick }) {
   const [enlargedAvatar, setEnlargedAvatar] = useState(null);
   const { authenticated, user } = useAuth();
-  const [selectedProfileNetid, setSelectedProfileNetid] = useState(null);
-  const [showProfileModal, setShowProfileModal] = useState(false);
+  const navigate = useNavigate();
+  const location = useLocation();
   // State for storing fetched titles per player netid
   const [playerTitlesMap, setPlayerTitlesMap] = useState({});
   
@@ -19,8 +19,7 @@ function PlayerStatusBar({ players, isRaceInProgress, currentUser, onReadyClick 
   
   const handleAvatarClick = (avatar, netid) => {
     if (authenticated) {
-      setSelectedProfileNetid(netid);
-      setShowProfileModal(true);
+      navigate(`/profile/${netid}`, { state: { backgroundLocation: location } });
     } else {
       setEnlargedAvatar({ url: avatar || defaultProfileImage, netid });
       // Prevent scrolling when modal is open
@@ -200,14 +199,6 @@ function PlayerStatusBar({ players, isRaceInProgress, currentUser, onReadyClick 
             </div>
           </div>
         </div>
-      )}
-      {/* Profile Modal for viewing user profiles (authenticated users) */}
-      {authenticated && showProfileModal && (
-        <ProfileModal
-          isOpen={showProfileModal}
-          onClose={() => setShowProfileModal(false)}
-          netid={selectedProfileNetid}
-        />
       )}
     </>
   );

--- a/client/src/components/ProfileWidget.jsx
+++ b/client/src/components/ProfileWidget.jsx
@@ -1,8 +1,8 @@
 // merge conflict debugged with ai
 
 import PropTypes from 'prop-types';
-import ProfileModal from './ProfileModal.jsx';
 import { useState, useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
 import './ProfileWidget.css';
 import axios from 'axios';
 
@@ -11,7 +11,6 @@ import defaultProfileImage from '../assets/icons/default-profile.svg';
 
 // Accept a layout prop ('default' or 'navbar')
 function ProfileWidget({ user, onClick, layout = 'default' }) {
-  const [showProfileModal, setShowProfileModal] = useState(false);
   // Local state for titles (use provided or fetch)
   const [titles, setTitles] = useState(user?.titles || []);
 
@@ -21,13 +20,11 @@ function ProfileWidget({ user, onClick, layout = 'default' }) {
     return typeof value === 'string' ? parseFloat(value) : value;
   };
   
-  // Define these functions at component level, not inside conditional branches
-  const openProfileModal = () => {
-    setShowProfileModal(true);
-  };
+  const navigate = useNavigate();
+  const location = useLocation();
 
-  const closeProfileModal = () => {
-    setShowProfileModal(false);
+  const openProfileModal = () => {
+    navigate(`/profile/${user?.netid}`, { state: { backgroundLocation: location } });
   };
 
   // Fetch titles if not provided
@@ -90,17 +87,9 @@ function ProfileWidget({ user, onClick, layout = 'default' }) {
 
   // Otherwise, use our own modal
   return (
-    <>
-      <div className="profile-widget-clickable" onClick={openProfileModal} role="button" tabIndex={0}>
-        {content}
-      </div>
-      
-      {showProfileModal && (<ProfileModal 
-      netid={user?.netid}
-      isOpen={showProfileModal} 
-      onClose={closeProfileModal} 
-      />)}
-    </>
+    <div className="profile-widget-clickable" onClick={openProfileModal} role="button" tabIndex={0}>
+      {content}
+    </div>
   );
 }
 

--- a/client/src/components/Results.jsx
+++ b/client/src/components/Results.jsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useRace } from '../context/RaceContext';
 import { useAuth } from '../context/AuthContext';
 import { useState, useCallback, useEffect } from 'react';
@@ -8,16 +8,13 @@ import './Results.css';
 import axios from 'axios';
 import defaultProfileImage from '../assets/icons/default-profile.svg';
 import PropTypes from 'prop-types';
-import ProfileModal from './ProfileModal.jsx';
 
 function Results({ onShowLeaderboard }) {
   const navigate = useNavigate();
   const { raceState, typingState, resetRace, joinPublicRace } = useRace();
   const { isRunning, endTutorial } = useTutorial();
   const { user } = useAuth();
-  // State for profile modal
-  const [selectedProfileNetid, setSelectedProfileNetid] = useState(null);
-  const [showProfileModal, setShowProfileModal] = useState(false);
+  const location = useLocation();
   // State for storing fetched titles for result players
   const [resultTitlesMap, setResultTitlesMap] = useState({});
   
@@ -58,17 +55,8 @@ function Results({ onShowLeaderboard }) {
   
   // Handle avatar click to show profile modal
   const handleAvatarClick = (_avatar, netid) => {
-    setSelectedProfileNetid(netid);
-    setShowProfileModal(true);
-    document.body.style.overflow = 'hidden';
+    navigate(`/profile/${netid}`, { state: { backgroundLocation: location } });
   };
-  
-  // Close profile modal
-  const closeModal = useCallback(() => {
-    setShowProfileModal(false);
-    setSelectedProfileNetid(null);
-    document.body.style.overflow = '';
-  }, []);
   
   // Add handler to queue another public race
   const handleQueueNext = () => {
@@ -338,14 +326,6 @@ function Results({ onShowLeaderboard }) {
         </button>
       </div>
       
-      {/* Profile Modal for viewing user profiles */}
-      {showProfileModal && (
-        <ProfileModal
-          isOpen={showProfileModal}
-          onClose={closeModal}
-          netid={selectedProfileNetid}
-        />
-      )}
     </>
   );
 }

--- a/client/src/pages/Lobby.jsx
+++ b/client/src/pages/Lobby.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useRace } from '../context/RaceContext';
 import { useAuth } from '../context/AuthContext';
 import { useSocket } from '../context/SocketContext'; // Import useSocket
@@ -7,7 +7,6 @@ import TestConfigurator from '../components/TestConfigurator';
 import ProfileWidget from '../components/ProfileWidget';
 import Modal from '../components/Modal';
 import Loading from '../components/Loading';
-import ProfileModal from '../components/ProfileModal'; // Import ProfileModal
 import './Lobby.css';
 import './Race.css';
 
@@ -34,9 +33,7 @@ function Lobby() {
 
   const [isLoading, setIsLoading] = useState(true);
   const [showCopiedMessage, setShowCopiedMessage] = useState(false);
-  // State for viewing other users' profiles
-  const [showProfileModal, setShowProfileModal] = useState(false);
-  const [selectedProfileNetid, setSelectedProfileNetid] = useState(null);
+  const location = useLocation();
 
   // Check if the current user is the host
   const isHost = user?.netid === raceState.hostNetId;
@@ -145,23 +142,10 @@ function Lobby() {
     updateLobbySettings(updatedSettings);
   };
 
-  // --- Profile Modal Handlers ---
-  const openProfileModal = (netid) => {
-    setSelectedProfileNetid(netid); // netid might be null if viewing self
-    setShowProfileModal(true);
-  };
-
-  const closeProfileModal = () => {
-    setShowProfileModal(false);
-    setSelectedProfileNetid(null);
-  };
-
   // Handles clicks on player widgets
   const handlePlayerClick = (playerNetId) => {
-    // Open the modal, passing the netid of the clicked player
-    openProfileModal(playerNetId);
+    navigate(`/profile/${playerNetId}`, { state: { backgroundLocation: location } });
   };
-  // --- End Profile Modal Handlers ---
 
   const handleCopyInviteLink = () => {
     const inviteLink = `${window.location.origin}/lobby/${raceState.code}`;
@@ -328,14 +312,6 @@ function Lobby() {
         )}
       </div>
 
-      {/* Profile Modal */} 
-      {showProfileModal && (
-        <ProfileModal
-          isOpen={showProfileModal}
-          onClose={closeProfileModal}
-          netid={selectedProfileNetid} // Pass the selected netid
-        />
-      )}
     </div>
   );
 }


### PR DESCRIPTION
…l routes, enabling the browser back button to close profile modals

Updated profile widget navigation to push /profile/:netid onto history so the back button closes the modal

Modified leaderboard entries to navigate to profile modals instead of toggling local state

Changed player status bar avatars to open profile modals via navigation for authenticated users

Lobby player clicks now navigate to a profile modal using location state

Result listings launch profile modals using navigate() to support browser back behavior